### PR TITLE
replaced run-shell-command

### DIFF
--- a/run_python.lisp
+++ b/run_python.lisp
@@ -13,7 +13,7 @@
 (defun runpy_wordnet(str_word)
 	"Lisp-Python interface for wordnet"
 		(with-output-to-string (asdf::*verbose-out*) 
-			(asdf:run-shell-command 
+			(uiop:run-program
 				(concatenate 'string "python wordnetpy.py " str_word
 				)
 			)


### PR DESCRIPTION
I replaced from asdf:run-shell-command to uiop:run-program.
Because, this kind of warning comes out.

```common-lisp
WARNING:
   DEPRECATED-FUNCTION-STYLE-WARNING: Using deprecated function ASDF/BACKWARD-INTERFACE:RUN-SHELL-COMMAND -- please update your code to use a newer API.
The docstring for this function says:
PLEASE DO NOT USE. This function is not just DEPRECATED, but also dysfunctional.
Please use UIOP:RUN-PROGRAM instead.
```